### PR TITLE
Fixed memory leak in xftw

### DIFF
--- a/xftw.h
+++ b/xftw.h
@@ -41,8 +41,9 @@
 #define	_XFTW_H_
 
 
-// BSD systems don't have lstat64 & stat64 monikers
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+// BSD systems don't have lstat64 & stat64 monikers and Apple uses 64-bit
+// structures by default
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
 
 #define stat64  stat
 #define lstat64 lstat


### PR DESCRIPTION
The function 'xftw' was leaking every entry in the list that it generated as it ran. It will now cleanup list items as it is finished with them.

Incidentally, this pull request also adds OS X compilation support as I am working on OS X.
