### PR TITLE
BUG: CMakeLists.txt was pointing to header in wrong directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,4 +29,4 @@ add_library(xftw SHARED
     )
 
 install (TARGETS xftw DESTINATION lib)
-install (FILES "${PROJECT_BINARY_DIR}/xftw.h" DESTINATION include)
+install (FILES xftw.h DESTINATION include)


### PR DESCRIPTION
The header will not be in the binary directory because it is a source file and is not being explicitly copied.
